### PR TITLE
Issue 1: Fix string truncation and empty plaintexts

### DIFF
--- a/printer/printSubpod.js
+++ b/printer/printSubpod.js
@@ -21,7 +21,10 @@ function printPlaintext(output, plaintext, options) {
 
   // Print multiple lines of plaintext
   if (plaintext[0].length !== plaintext[1].length) {
-    output.putText(plaintext.map(line => line.join(options.columnDelimiter)).join('\n'));
+    output.putText(plaintext.filter(line => line.join(''))
+                            .map(line => line.filter(line => line).join(' '))
+                            .join('\n')
+                  );
     return;
   }
 

--- a/printer/printSubpod.js
+++ b/printer/printSubpod.js
@@ -21,7 +21,7 @@ function printPlaintext(output, plaintext, options) {
 
   // Print multiple lines of plaintext
   if (plaintext[0].length !== plaintext[1].length) {
-    output.putText(plaintext.map(line => line.join('')).join('\n'));
+    output.putText(plaintext.map(line => line.join(options.columnDelimiter)).join('\n'));
     return;
   }
 


### PR DESCRIPTION
Strings can get truncated if there is more than one `plaintext` in a `subPod`. 
Like this: 
`Nearby feature`
`mountainSveti Jure (1762 meters)20 km  (kilometers) east`

`Nearby airport`
`Kastel13 km  (kilometers) west‐northwest`

Also, a `subPod` may contain empty `plaintext` arrays, which this tries to fix (in a crude way). See:
`"plaintext": [
            [
              ""
            ],
            [
              "",
              ""
            ],
            [
              "maximum: 0.4 mm/h"
            ],
            [
              "Wed, Sep 7, 5:00pm"
            ],
            [
              ""
            ]`
